### PR TITLE
Update kd-SIMPLEXColonies-OASIS.cfg

### DIFF
--- a/GameData/KeridianDynamics/Parts/kd-SIMPLEXColonies-OASIS.cfg
+++ b/GameData/KeridianDynamics/Parts/kd-SIMPLEXColonies-OASIS.cfg
@@ -4,7 +4,7 @@
 // updated: 13 Jun 2023
 
 // THIS FILE: CC BY-SA 4.0 by [Eleusis La Arwall](https://github.com/EleusisLaArwall) and [zer0Kerbal](https://github.com/zer0Kerbal)
-PART:NEEDS[SIMPLEXColonies]
+PART:NEEDS[AngleCanMods/SIMPLEXStationParts]
 {
 	name = KD-SIMPLEXColonies-oasis
 	module = Part


### PR DESCRIPTION
This changes the NEEDS to the correct path way, and changes the mod focus to the new SIMPLEXStationParts rather than SIMPLEXColonies.